### PR TITLE
Modified GIF background transparency

### DIFF
--- a/2D/image.c
+++ b/2D/image.c
@@ -6,12 +6,13 @@ cairo_surface_t* cairo_image_surface_create_from_jpg(const char* filename);
 
 
 //draw a png file to surface
-//draw_image <channel>,<file_name>,<dst_x>,<dst_y>,<src_x>,<src_y>,<dst_width>,<dst_height>,<src_width>,<src_height>,<speed>,<max_loops>
+//draw_image <channel>,<file_name>,<dst_x>,<dst_y>,<src_x>,<src_y>,<dst_width>,<dst_height>,<src_width>,<src_height>,<speed>,<max_loops>,<gif_trans>
 void draw_image(thread_context* context, char* args) {
     char filename[MAX_VAL_LEN] = { 0 };
     char fileext[MAX_VAL_LEN] = { 0 };
     int channel = 0, max_loops = 0, src_x = 0, src_y = 0, src_width = 0, src_height = 0, i;
     double dst_x = 0.0, dst_y = 0.0, dst_width = 0.0, dst_height = 0.0;
+	int gif_trans = 1;
     double speed = 1.0;
     bool is_gif = false;
     gd_GIF* gif = NULL;
@@ -75,8 +76,9 @@ void draw_image(thread_context* context, char* args) {
         args = read_int(args, &src_height);
         args = read_double(args, &speed);
         args = read_int(args, &max_loops);
+        args = read_int(args, &gif_trans);
 
-        if (debug) printf("draw_image %d,%s,%s,%f,%f,%d,%d,%f,%f,%d,%d,%f,%d\n", channel, filename, fileext, dst_x, dst_y, src_x, src_y, dst_width, dst_height, src_width, src_height, speed, max_loops);
+        if (debug) printf("draw_image %d,%s,%s,%f,%f,%d,%d,%f,%f,%d,%d,%f,%d,%d\n", channel, filename, fileext, dst_x, dst_y, src_x, src_y, dst_width, dst_height, src_width, src_height, speed, max_loops, gif_trans);
 
 
         double xScale = dst_width / (float)src_width;
@@ -108,7 +110,7 @@ void draw_image(thread_context* context, char* args) {
                     unsigned char* color = gif_buffer;
                     for (unsigned int y = 0; y < gif->height; y++) {
                         for (unsigned int x = 0; x < gif->width; x++) {
-                            if (gd_is_bgcolor(gif, color)) {
+                            if ((gif_trans!=0) && (gd_is_bgcolor(gif, color))) {
                                 pixels[y * cairo_stride + x] = 0; //full transparent
                             }else{
                                 pixels[y * cairo_stride + x] =  convert_cairo_color((*((unsigned int*)color)) & 0xFFFFFF);

--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -549,7 +549,7 @@ draw_circle <channel>,<x>,<y>,<radius>,<color>,<border_width>,<border_color>,<st
 * `draw_image` draws an image file
 
 ```
-draw_image <channel>,<file_name>,<dst_x>,<dst_y>,<src_x>,<src_y>,<dst_width>,<dst_height>,<src_width>,<src_height>,<speed>,<max_loops>
+draw_image <channel>,<file_name>,<dst_x>,<dst_y>,<src_x>,<src_y>,<dst_width>,<dst_height>,<src_width>,<src_height>,<speed>,<max_loops>,<gif_trans>
 This will paint a JPG, PNG or (animated) GIF to the LED matrix.
 
 # <channel>			Channel number
@@ -564,6 +564,7 @@ This will paint a JPG, PNG or (animated) GIF to the LED matrix.
 # <src_height> 		Source height, change together with src_width
 # <speed>			If the file is an animated gif, specify here a speed multiplier, for example 2 will play at twice the speed. default is 1
 # <max_loops>		for animated gif only Stop repeating the animation after max_loops, default 0 = inifite loops or loops defined in the GIF
+# <gif_trans>		Draws GIF background when the value is 0, and transparaent when the value is 1 (default 1) 
 ```
 
 * `draw_line` draws an image file


### PR DESCRIPTION
Added a new parameter to use either background color or transparent

This is a solution for issue #73.
Sorry I can't see how to link this to the issue I raised, maybe I don't have the rights to do that.
I have attached the GIF that I wanted to use. I have trued it with both black and transparent background, but can see from the code that they will be treated the same.

For completenes the script I use is 

    kill_thread 1,0
    reset
    setup 1,512, 3
    init
    render
    brightness 1,120
    render

    config_2D 1,32,16,2,32,8

    thread_start 1
    set_thread_exit_type 1,0
    do
    draw_image 1,/home/pi/snow03.gif,0,0,100,100,32,16,256,128,1,1,0
    render 1
    loop
    thread_stop


![snow03](https://user-images.githubusercontent.com/21973866/208319084-3641f55b-7320-4a5d-9abf-c137ba7057a4.gif)
